### PR TITLE
Uncommented the Commands path line

### DIFF
--- a/getUpdatesCLI.php
+++ b/getUpdatesCLI.php
@@ -23,7 +23,7 @@ $admin_users = [
 
 // Define all paths for your custom commands in this array (leave as empty array if not used)
 $commands_paths = [
-//    __DIR__ . '/Commands/',
+  __DIR__ . '/Commands/',
 ];
 
 // Enter your MySQL database credentials


### PR DESCRIPTION
Suggestion:
Since the example-bot is meant as a quickstart there is no point in having the example commands path excluded, be it even only for a test of the setup before coding a custom command.