### PR TITLE
Update ImageCommand.php to handle '.' and '..' more reliable

### DIFF
--- a/Commands/ImageCommand.php
+++ b/Commands/ImageCommand.php
@@ -86,7 +86,7 @@ class ImageCommand extends UserCommand
     private function GetRandomImagePath($dir)
     {
         // Slice off the . and .. "directories"
-        if ($image_list = array_slice(scandir($dir, SCANDIR_SORT_NONE), 2)) {
+        if ($image_list = array_diff(scandir($dir), array('..', '.'))) {
             shuffle($image_list);
             return $dir . '/' . $image_list[0];
         }


### PR DESCRIPTION
On my system `array_slice(scandir($dir, SCANDIR_SORT_NONE), 2)` sometimes returns '.'