### PR TITLE
Update hook.php to load commands by default

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -22,7 +22,7 @@ $admin_users = [
 
 // Define all paths for your custom commands in this array (leave as empty array if not used)
 $commands_paths = [
-//    __DIR__ . '/Commands/',
+    __DIR__ . '/Commands/',
 ];
 
 // Enter your MySQL database credentials


### PR DESCRIPTION
Since the example-bot is meant as a quickstart there is no point in having the example commands excluded, be it even only for a test of the setup before coding a custom command.
Wasted some time figuring out why bot isn't working.