### PR TITLE
Extra quotaion marks removed

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -43,11 +43,11 @@ try {
     // (this example requires Monolog: composer require monolog/monolog)
     // Longman\TelegramBot\TelegramLog::initialize(
     //    new Monolog\Logger('telegram_bot', [
-    //        (new Monolog\Handler\StreamHandler($config['logging']['debug']", Monolog\Logger::DEBUG))->setFormatter(new Monolog\Formatter\LineFormatter(null, null, true)),
-    //        (new Monolog\Handler\StreamHandler($config['logging']['error']", Monolog\Logger::ERROR))->setFormatter(new Monolog\Formatter\LineFormatter(null, null, true)),
+    //        (new Monolog\Handler\StreamHandler($config['logging']['debug'], Monolog\Logger::DEBUG))->setFormatter(new Monolog\Formatter\LineFormatter(null, null, true)),
+    //        (new Monolog\Handler\StreamHandler($config['logging']['error'], Monolog\Logger::ERROR))->setFormatter(new Monolog\Formatter\LineFormatter(null, null, true)),
     //    ]),
     //    new Monolog\Logger('telegram_bot_updates', [
-    //        (new Monolog\Handler\StreamHandler($config['logging']['update']", Monolog\Logger::INFO))->setFormatter(new Monolog\Formatter\LineFormatter('%message%' . PHP_EOL)),
+    //        (new Monolog\Handler\StreamHandler($config['logging']['update'], Monolog\Logger::INFO))->setFormatter(new Monolog\Formatter\LineFormatter('%message%' . PHP_EOL)),
     //    ])
     // );
 


### PR DESCRIPTION
Removed additional quotation marks which were causing syntax errors. Were left from at last commit.